### PR TITLE
Added translation support and Spanish translation

### DIFF
--- a/MMM-TwitterTrendsByPlace.js
+++ b/MMM-TwitterTrendsByPlace.js
@@ -29,6 +29,12 @@ Module.register("MMM-TwitterTrendsByPlace", {
 		fade: false,
 		fadePoint: 0.5,
 	},
+	getTranslations: function() {
+		return {
+				en: "translations/en.json",
+				es: "translations/es.json",
+		}
+	},
 	// the start function
 	start: function() {
 		// log starting
@@ -40,7 +46,7 @@ Module.register("MMM-TwitterTrendsByPlace", {
 		this.error = false;
 		this.mostRecentUpdate = null;
 		// set the header to this place
-		this.data.header = "Twitter Trends For " + this.config.placeName;
+		this.data.header = this.translate("HEADER") + " " + this.config.placeName;
 		if ( (this.config.consumer_key != null) && (this.config.consumer_secret != null)
 				&& (this.config.access_token_key != null) && (this.config.access_token_secret != null)
 				&& (this.config.placeWoeid != null) )

--- a/MMM-TwitterTrendsByPlace.js
+++ b/MMM-TwitterTrendsByPlace.js
@@ -91,7 +91,7 @@ Module.register("MMM-TwitterTrendsByPlace", {
 		{
 			var wrapper = document.createElement("div");
 			wrapper.className = "xsmall";
-			wrapper.innerHTML = "Awaiting Trends...";
+			wrapper.innerHTML = this.translate("LOADING");
 			return wrapper;			
 		}
 		// main update handler
@@ -170,7 +170,7 @@ Module.register("MMM-TwitterTrendsByPlace", {
 		{
 			var wrapper = document.createElement("div");
 			wrapper.className = "xsmall";
-			wrapper.innerHTML = "Some Error Has Occured";
+			wrapper.innerHTML = this.translate("ERROR");
 			return wrapper;		
 		}		
 	}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,3 @@
+{
+	"HEADER": "Twitter Trends for"
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,3 +1,5 @@
 {
-	"HEADER": "Twitter Trends for"
+	"HEADER": "Twitter Trends for",
+	"LOADING": "Awaiting Trends...",
+	"ERROR": "Some error has ocurred"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,3 +1,5 @@
 {
-	"HEADER": "Tendencias de Twitter en"
+	"HEADER": "Tendencias de Twitter en",
+	"LOADING": "Cargando tendencias...",
+	"ERROR": "Ha ocurrido un error"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,3 @@
+{
+	"HEADER": "Tendencias de Twitter en"
+}


### PR DESCRIPTION
The header of this module is not localised, and can't be overriden in ``config.js``, so I made a quick fix for this.

New translators should only add the path of the translated ``.json`` into the ``getTranslations`` function.